### PR TITLE
Add a correct index offset in apply_copy and apply_skip

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -231,8 +231,6 @@ impl<'a, 'b, 'c> UpdateHelper<'a, 'b, 'c> {
         // Skip the valid lines
         let nb_valid_lines = old_lines.len();
         if nb_lines < nb_valid_lines as u64 {
-            let range = 0..nb_lines;
-
             // The min value of the old_lines' hash keys.
             // This is required in order to correctly perform the operation
             // "remove first 'nb_lines' elements from old_lines".
@@ -240,8 +238,9 @@ impl<'a, 'b, 'c> UpdateHelper<'a, 'b, 'c> {
             // (That is, a removal by keys min_index, min_index+1, ...,
             // min_index+nb_lines).
             let min_index = *old_lines.keys().min().unwrap();
+            let range = min_index..nb_lines + min_index;
 
-            range.map(|i| old_lines.remove(&(i+min_index))).last();
+            range.map(|i| old_lines.remove(&i)).last();
             return;
         } else {
             old_lines.clear();
@@ -304,7 +303,8 @@ impl<'a, 'b, 'c> UpdateHelper<'a, 'b, 'c> {
             panic!("failed to update the cache");
         }
 
-        let range = 0..nb_lines;
+        let min_index = *old_lines.keys().min().unwrap();
+        let range = min_index..nb_lines + min_index;
 
         new_lines.extend(
             range

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -27,9 +27,21 @@ impl LineCache {
         self.invalid_after
     }
 
+    /// Retrieve the line with the given number from the cache.
     pub fn get_line(&self, n: u64) -> Option<&Line> {
-        self.lines.get(&n)
+        // TODO this is a naive search by value. May want to make use of the
+        // contiguity of the cache lines (HashMap::get(<min of keys...> + n))
+        // for optimization, but need to establish cache contiguity checks
+        // first.
+        self.lines.iter().find_map(|(_,line)| {
+            if Some(n+1) == line.line_num {
+                Some(line)
+            } else {
+                None
+            }
+        })
     }
+
     /// Retrieve all lines in the cache.
     pub fn lines(&self) -> &HashMap<u64, Line> {
         &self.lines

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -27,21 +27,9 @@ impl LineCache {
         self.invalid_after
     }
 
-    /// Retrieve the line with the given number from the cache.
     pub fn get_line(&self, n: u64) -> Option<&Line> {
-        // TODO this is a naive search by value. May want to make use of the
-        // contiguity of the cache lines (HashMap::get(<min of keys...> + n))
-        // for optimization, but need to establish cache contiguity checks
-        // first.
-        self.lines.iter().find_map(|(_,line)| {
-            if Some(n+1) == line.line_num {
-                Some(line)
-            } else {
-                None
-            }
-        })
+        self.lines.get(&n)
     }
-
     /// Retrieve all lines in the cache.
     pub fn lines(&self) -> &HashMap<u64, Line> {
         &self.lines

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -166,7 +166,15 @@ impl<'a, 'b, 'c> UpdateHelper<'a, 'b, 'c> {
                 0
             };
 
-            let copied_lines = range.filter_map(|i| old_lines.remove_entry(&(i as u64))).map(|(i, mut line)| {
+            // The min value of the old_lines' hash keys.
+            // This is required in order to correctly perform the operation
+            // "remove first 'nb_lines' elements from old_lines".
+            //
+            // (That is, a removal by keys min_index, min_index+1, ...,
+            // min_index+nb_lines).
+            let min_index = *old_lines.keys().min().unwrap();
+
+            let copied_lines = range.filter_map(|i| old_lines.remove_entry(&((i+(min_index as usize)) as u64))).map(|(i, mut line)| {
                 line.line_num = line
                     .line_num
                     .map(|line_num| (line_num as i64 + diff) as u64);
@@ -224,7 +232,16 @@ impl<'a, 'b, 'c> UpdateHelper<'a, 'b, 'c> {
         let nb_valid_lines = old_lines.len();
         if nb_lines < nb_valid_lines as u64 {
             let range = 0..nb_lines;
-            range.map(|i| old_lines.remove(&i)).last();;
+
+            // The min value of the old_lines' hash keys.
+            // This is required in order to correctly perform the operation
+            // "remove first 'nb_lines' elements from old_lines".
+            //
+            // (That is, a removal by keys min_index, min_index+1, ...,
+            // min_index+nb_lines).
+            let min_index = *old_lines.keys().min().unwrap();
+
+            range.map(|i| old_lines.remove(&(i+min_index))).last();
             return;
         } else {
             old_lines.clear();

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -181,13 +181,21 @@ impl<'a, 'b, 'c> UpdateHelper<'a, 'b, 'c> {
             // The resulting new_lines' keys should form a contiguous sequence.
             // If that is not true, the application should panic at once.
             let min_old_index = *old_lines.keys().min().unwrap();
-            let max_new_index = *new_lines.keys().max().unwrap_or(&0);
+            let max_new_index = new_lines.keys().max();
+
+            // Calculate the position in new_lines to insert into.
+            // Empty new_lines is a special case.
+            let new_index = if let Some(max_new_index) = max_new_index {
+                *max_new_index + 1
+            } else {
+                0
+            };
 
             let copied_lines = range.filter_map(|i| old_lines.remove_entry(&((i+(min_old_index as usize)) as u64))).map(|(i, mut line)| {
                 line.line_num = line
                     .line_num
                     .map(|line_num| (line_num as i64 + ln_diff) as u64);
-                ((i + max_new_index - min_old_index + 1) as u64, line)
+                ((i + new_index - min_old_index) as u64, line)
             });
 
             new_lines.extend(copied_lines);

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -178,7 +178,7 @@ impl<'a, 'b, 'c> UpdateHelper<'a, 'b, 'c> {
                 line.line_num = line
                     .line_num
                     .map(|line_num| (line_num as i64 + diff) as u64);
-                (i, line)
+                ((i as i64 + diff) as u64, line)
             });
 
             new_lines.extend(copied_lines);


### PR DESCRIPTION
This change fixes the crash of "edit_cargo_toml" benchmark in the hashmap branch.

This fn was crashing because, as of the original Vec<Line> implementation, removing a range [0..nb_lines] from the vector works as expected (=the first nb_lines in the vector are removed) but in case of HashMap<u64, Line>, there is no ordered array of lines, and the hash's keys are "some_index, some_index+1, ..., etc" (going in unspecified order) rather than "0, 1, ...". Thus, one should not index into HashMap with something like `[0..nb_lines].iter.map(|i| old_lines.remove(&i)`.

The correct action is removal by keys min_index, min_index+1, ..., min_index+nb_lines.